### PR TITLE
dotnet test verbosity normal

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -104,8 +104,8 @@ _testCore() {
     testName=$(basename "$testFullName")
     #testResultName="$testNameWOExtension-$(date +%Y%m%d-%H%M%S_%N)"
 
-    #dotnetTestArgs=("-c ${BUILD_CONFIG}" "--no-build" "--verbosity minimal" "--logger \"trx;LogFileName=${testResultName}.trx\"")
-    dotnetTestArgs=("-c ${BUILD_CONFIG}" "--no-build" "--verbosity minimal" "--logger \"trx\"")
+    #dotnetTestArgs=("-c ${BUILD_CONFIG}" "--no-build" "--verbosity normal" "--logger \"trx;LogFileName=${testResultName}.trx\"")
+    dotnetTestArgs=("-c ${BUILD_CONFIG}" "--no-build" "--verbosity normal" "--logger \"trx\"")
 
     if [[ -n "$TESTS_TO_SKIP" ]]; then
         testsToSkip=(${TESTS_TO_SKIP//;/ })

--- a/tests/Calculator.Core.Tests/CalculatorTests/Add.cs
+++ b/tests/Calculator.Core.Tests/CalculatorTests/Add.cs
@@ -1,4 +1,6 @@
-﻿using NUnit.Framework;
+using System.IO;
+using System.Text.Json;
+using NUnit.Framework;
 
 namespace Calculator.Core.Tests.CalculatorTests
 {
@@ -8,16 +10,21 @@ namespace Calculator.Core.Tests.CalculatorTests
         [Test]
         public void Summands_given___correct_result()
         {
+            TestContext.WriteLine("Sending some messages to Progess for demo purposes");
+
             // Arrange
+            TestContext.Progress.WriteLine("Arrange");
             int first  = 3;
             int second = 4;
 
             var sut = new Calculator();
 
             // Act:
+            TestContext.Progress.WriteLine("Act");
             int actual = sut.Add(first, second);
 
             // Assert:
+            TestContext.Progress.WriteLine("Assert");
             Assert.AreEqual(7, actual);
         }
         //---------------------------------------------------------------------
@@ -32,6 +39,30 @@ namespace Calculator.Core.Tests.CalculatorTests
             int actual = sut.Add(first, second);
 
             Assert.AreEqual(first, actual);
+        }
+        //---------------------------------------------------------------------
+        [Test]
+        public void Summands_given___output_written_to_json_and_attached()
+        {
+            int first  = 42;
+            int second = 666;
+
+            var sut = new Calculator();
+
+            int actual = sut.Add(first, second);
+
+            using (var fs         = File.OpenWrite("res.json"))
+            using (var jsonWriter = new Utf8JsonWriter(fs, new JsonWriterOptions { Indented = true }))
+            {
+                jsonWriter.WriteStartObject();
+                jsonWriter.WriteNumber("first", first);
+                jsonWriter.WriteNumber("second", second);
+                jsonWriter.WriteNumber("result", actual);
+                jsonWriter.WriteEndObject();
+            }
+
+            TestContext.AddTestAttachment("res.json");
+            TestContext.AddTestAttachment("res.json", "Attachment with description");
         }
     }
 }


### PR DESCRIPTION
Shows more info than `minimal` (which was set in 55e83552602d9e19ec6e45258cca7255334b0f5c), and I don't see any problems in Azure DevOps' output.