### PR TITLE
Don't trigger CI builds in outer-loop

### DIFF
--- a/.azure/pipelines/outer-loop.yml
+++ b/.azure/pipelines/outer-loop.yml
@@ -6,6 +6,7 @@ variables:
   TAG_NAME: $(Build.SourceBranchName)
 
 trigger: none
+pr: none
 
 schedules:
   - cron: "0 0 * * *"

--- a/.azure/pipelines/outer-loop.yml
+++ b/.azure/pipelines/outer-loop.yml
@@ -6,7 +6,6 @@ variables:
   TAG_NAME: $(Build.SourceBranchName)
 
 trigger: none
-pr: none
 
 schedules:
   - cron: "0 0 * * *"

--- a/.azure/pipelines/outer-loop.yml
+++ b/.azure/pipelines/outer-loop.yml
@@ -6,6 +6,9 @@ variables:
   TAG_NAME: $(Build.SourceBranchName)
 
 trigger: none
+# pr trigger must not be excluded, but in the UI for the pipeline definition a setting has to be made.
+# See https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers
+# for further info.
 
 schedules:
   - cron: "0 0 * * *"

--- a/.azure/pipelines/outer-loop.yml
+++ b/.azure/pipelines/outer-loop.yml
@@ -5,6 +5,8 @@ variables:
   BRANCH_NAME: $(Build.SourceBranchName)
   TAG_NAME: $(Build.SourceBranchName)
 
+trigger: none
+
 schedules:
   - cron: "0 0 * * *"
     displayName: "Daily midnight build"


### PR DESCRIPTION
Sequel to https://github.com/gfoidl-Tests/Continuous-Integration-Test/pull/18